### PR TITLE
Configure Claude integration for Node and Python containers

### DIFF
--- a/node/docker-compose.yaml
+++ b/node/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
       NODE_PATH: "/tmp/node_modules"
       SAM_CLI_TELEMETRY: 0
       SST_TELEMETRY_DISABLED: 1
+      CLAUDE_CONFIG_DIR: /root/.claude
     image: d_n:22
-    # image: d_n_spo
     volumes:
       - type: bind
         source: "${FOLDER}"
@@ -13,12 +13,18 @@ services:
       - type: bind
         source: "$HOME/Downloads"
         target: /data
+      # - type: bind
+      #   source: "${HOME}/.aws"
+      #   target: /root/.aws
+      #   read_only: true
       - type: bind
-        source: "${HOME}/.aws"
-        target: /root/.aws
-        read_only: true
+        source: ./volume/vscode-server
+        target: /root/.vscode-server
+      - type: bind
+        source: ./volume/claude
+        target: /root/.claude
     tty: true
     entrypoint: /bin/bash
-    ports:
-      - "3000:3000"
-      - "5555:5555"
+    #ports:
+      #- "3000:3000"
+      #- "5555:5555"

--- a/py/docker-compose.yaml
+++ b/py/docker-compose.yaml
@@ -1,7 +1,8 @@
 services:
   app:
     image: d_p
-    # image: mcr.microsoft.com/vscode/devcontainers/python:dev-3.12
+    environment:
+      CLAUDE_CONFIG_DIR: /root/.claude
     volumes:
       - type: bind
         source: "${FOLDER}"
@@ -17,10 +18,10 @@ services:
         source: ./volume/vscode-server
         target: /root/.vscode-server
       - type: bind
-        source: ./volume/amazonq
-        target: /root/.aws/amazonq
+        source: ./volume/.claude
+        target: /root/.claude
     tty: true
     entrypoint: /bin/bash
-    ports:
-      - "3000"
-      - "57890"
+    #ports:
+    #  - "3500"
+    #  - "57890"


### PR DESCRIPTION
## Configure Claude integration for Node and Python containers

Adds Claude AI support to development environments by:
- Adding `CLAUDE_CONFIG_DIR` environment variable to both services
- Mounting Claude configuration volumes for persistent settings
- Node: `./volume/claude` → `/root/.claude`
- Python: `./volume/.claude` → `/root/.claude`

This enables Claude AI assistance within containers while maintaining configuration persistence across restarts.