### PR TITLE
chore: upgrade dev containers with Claude CLI and Docker support

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,8 +1,9 @@
-FROM node:22-bullseye
+FROM node:24-slim
 
 # basic setup
-RUN apt-get update -y && apt-get upgrade -y &&\
-  apt-get install -y git tmux vim zip &&\
+RUN apt-get update -y &&\
+  apt-get install -y git tmux vim curl &&\
+  rm -rf /var/lib/apt/lists/* &&\
   echo 'set number tabstop=2 shiftwidth=2 expandtab' >> /root/.vimrc &&\
   echo 'alias ls="ls --color=auto"' >> /root/.bashrc &&\
   echo 'export LC_ALL="C.UTF-8"' >> /root/.bashrc &&\
@@ -10,5 +11,8 @@ RUN apt-get update -y && apt-get upgrade -y &&\
   # see https://github.com/pnpm/pnpm/issues/5803
   pnpm config set store-dir /home/node/.local/share/pnpm/store &&\
   SHELL=bash pnpm setup && . /root/.bashrc && pnpm i -g vercel
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+RUN curl -fsSL https://claude.ai/install.sh | bash &&\
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> /root/.bashrc
 
 ENTRYPOINT ["/bin/bash"]

--- a/node/docker-compose.yaml
+++ b/node/docker-compose.yaml
@@ -1,11 +1,11 @@
 services:
-  node:
+  app:
+    image: d_n:24
     environment:
       NODE_PATH: "/tmp/node_modules"
       SAM_CLI_TELEMETRY: 0
       SST_TELEMETRY_DISABLED: 1
       CLAUDE_CONFIG_DIR: /root/.claude
-    image: d_n:22
     volumes:
       - type: bind
         source: "${FOLDER}"
@@ -21,8 +21,9 @@ services:
         source: ./volume/vscode-server
         target: /root/.vscode-server
       - type: bind
-        source: ./volume/claude
+        source: ./volume/.claude
         target: /root/.claude
+      - /var/run/docker.sock:/var/run/docker.sock
     tty: true
     entrypoint: /bin/bash
     #ports:

--- a/py/Dockerfile
+++ b/py/Dockerfile
@@ -1,11 +1,14 @@
-FROM python:3.12
+FROM python:3.14-slim
 
 # basic setup
-RUN apt-get update -y && apt-get upgrade -y
-RUN apt-get install -y git tmux vim zip &&\
-  # apt-get install -y python3-dev &&\
+RUN apt-get update -y &&\
+ apt-get install -y git tmux vim curl &&\
+  rm -rf /var/lib/apt/lists/* &&\
   echo 'set number tabstop=4 shiftwidth=4 expandtab' >> /root/.vimrc &&\
   echo 'alias ls="ls --color=auto"' >> /root/.bashrc &&\
-  echo 'export LC_ALL="C.UTF-8"' >> /root/.bashrca
+  echo 'export LC_ALL="C.UTF-8"' >> /root/.bashrc
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+RUN curl -fsSL https://claude.ai/install.sh | bash &&\
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> /root/.bashrc
 
 ENTRYPOINT ["/bin/bash"]

--- a/py/docker-compose.yaml
+++ b/py/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: d_p
+    image: d_p:latest
     environment:
       CLAUDE_CONFIG_DIR: /root/.claude
     volumes:
@@ -20,6 +20,7 @@ services:
       - type: bind
         source: ./volume/.claude
         target: /root/.claude
+      - /var/run/docker.sock:/var/run/docker.sock
     tty: true
     entrypoint: /bin/bash
     #ports:


### PR DESCRIPTION
- Node: 22-bullseye → 24-slim
- Python: 3.12 → 3.14-slim
- Add Claude CLI installation to both containers
- Add Docker CLI binary mounting
- Fix Python typo (.bashrca → .bashrc)
- Standardize volume paths and add docker.sock mounting