### PR TITLE
refactor: simplify agent_toolkit docker-compose configuration

### DIFF
--- a/agent_toolkit/cipher/docker-compose.yml
+++ b/agent_toolkit/cipher/docker-compose.yml
@@ -17,9 +17,6 @@ services:
 
   cipher:
     image: cipher-cipher:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: cipher-mcp
     ports:
       - "5000:5000"  # If using HTTP transport

--- a/agent_toolkit/context7/docker-compose.yml
+++ b/agent_toolkit/context7/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   context7-mcp:
     image: context7-mcp:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: context7-mcp
     stdin_open: true
     command: context7-mcp

--- a/agent_toolkit/docker-compose.yml
+++ b/agent_toolkit/docker-compose.yml
@@ -2,4 +2,3 @@ include:
   - ./cipher/docker-compose.yml
   - ./context7/docker-compose.yml
   - path: ./serena/docker-compose.yml
-    env_file: .env

--- a/agent_toolkit/serena/docker-compose.yml
+++ b/agent_toolkit/serena/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   serena-mcp:
     image: serena-mcp:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: serena-mcp
     # ports:
     #   - "8000:8000"  # Web dashboard


### PR DESCRIPTION
Remove build sections from cipher, context7, and serena compose files, and remove env_file reference from main compose file. This assumes images are pre-built before running docker-compose.